### PR TITLE
Build sources and javadoc with Gradle

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A GraphQL Query Generator using annotation processing
 
 # Creating jars
 Simply run
-```./gradlew jar sourcesJar javadocJar```
+`./gradlew jar sourcesJar javadocJar`
 from the command line, or configure the gradle tasks from
 your IDE's build configuration.
 
@@ -12,4 +12,4 @@ In Intellij IDEA, create a "Gradle" build configuration like so:
 Gradle Project:         /path/to/build.gradle
 Tasks:                  jar sourcesJar javadocJar
 
-![Screenshot of the Intellij IDEA 'Configure Project' screen, as described.](http://imgur.com/uhjWNXn)
+![Screenshot of the Intellij IDEA 'Configure Project' screen, as described.](http://i.imgur.com/uhjWNXn.png)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,26 @@
 # graphQLQueryGen
 A GraphQL Query Generator using annotation processing
 
-# Creating jars
-Simply run
+# Building the library
+In most cases, you can just run
 `./gradlew jar sourcesJar javadocJar`
-from the command line, or configure the gradle tasks from
-your IDE's build configuration.
+from the command line.
 
-In Intellij IDEA, create a "Gradle" build configuration like so:
-
+You can also build them with an Intellij IDEA "Gradle" build configuration like so:
+```
 Gradle Project:         /path/to/build.gradle
 Tasks:                  jar sourcesJar javadocJar
+```
 
 ![Screenshot of the Intellij IDEA 'Configure Project' screen, as described.](http://i.imgur.com/uhjWNXn.png)
+
+In both cases, three Jar files will be placed in the
+'out' folder - just copy these over to use them in
+your own project.
+
+```groovy
+// In your personal project's build.gradle
+dependencies {
+    compile fileTree(include: ['*.jar'], dir: 'whatever/folder/you/put/the/jars/in')
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # graphQLQueryGen
 A GraphQL Query Generator using annotation processing
+
+# Creating jars
+Simply run
+```./gradlew jar sourcesJar javadocJar```
+from the command line, or configure the gradle tasks from
+your IDE's build configuration.
+
+In Intellij IDEA, create a "Gradle" build configuration like so:
+
+Gradle Project:         /path/to/build.gradle
+Tasks:                  jar sourcesJar javadocJar
+
+![Screenshot of the Intellij IDEA 'Configure Project' screen, as described.](http://imgur.com/uhjWNXn)

--- a/build.gradle
+++ b/build.gradle
@@ -13,3 +13,37 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
     compile 'com.squareup:javapoet:1.7.0'
 }
+
+// This puts all of the jar files into one folder, called 'out'.
+tasks.withType(Jar) {
+    destinationDir = file("$rootDir/out")
+}
+
+// This is an alternate implementation of the 'javadoc' task
+task javadocX(type: Javadoc) {
+    source = sourceSets.main.allJava
+    classpath += configurations.compile
+    // If we didn't specify this, destinationDir would be inaccessible
+    // from the javadocJar task.
+    destinationDir = file("./javadoc/")
+    failOnError false
+}
+
+// Simple task to bundle up the javadocX outputs
+task javadocJar(type: Jar, dependsOn: javadocX) {
+    classifier = 'javadoc'
+    //noinspection GroovyAssignabilityCheck - we know destinationDir is a directory
+    from javadocX.destinationDir
+}
+
+// A proper sources jar, with comments
+task sourcesJar(type: Jar, dependsOn: classes) {
+    classifier = 'sources'
+    from sourceSets.main.allSource
+}
+
+// Request sources and javadoc artifacts
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}

--- a/src/main/java/com/anthonyfdev/graphQLQueryGen/GraphQLField.java
+++ b/src/main/java/com/anthonyfdev/graphQLQueryGen/GraphQLField.java
@@ -5,6 +5,34 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Use this to mark Object fields that can be used in a GraphQL query.
+ * <p>
+ * The name of the marked field will be used directly in the query:
+ * for example, the definition
+ * <pre>
+ *{@literal @}GraphQLObject
+ * public class Product {
+ *    {@literal @}GraphQLField
+ *     public String name;
+ *
+ *    {@literal @}GraphQLField
+ *     public float height;
+ *
+ *    {@literal @}GraphQLField(type = "isKnown")
+ *     public boolean available;
+ * }
+ * </pre>
+ * will be treated as the following piece of GraphQL:
+ * <pre>
+ * {
+ *     name
+ *     height
+ *     available : isKnown
+ * }
+ * </pre>
+ * </p>
+ */
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.FIELD)
 public @interface GraphQLField {

--- a/src/main/java/com/anthonyfdev/graphQLQueryGen/GraphQLObject.java
+++ b/src/main/java/com/anthonyfdev/graphQLQueryGen/GraphQLObject.java
@@ -5,6 +5,12 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Marker interface for classes whose fields should be serialized
+ * into a GraphQL query.
+ *
+ * @see GraphQLField
+ */
 @Retention(RetentionPolicy.SOURCE)
 @Target(ElementType.TYPE)
 public @interface GraphQLObject {


### PR DESCRIPTION
You can now build sources- and javadoc-jars right from Gradle

We've also got improved javadoc on the annotation classes and
instructions about how to build the jars in the README.